### PR TITLE
Optimize cnv installation

### DIFF
--- a/cmds/cnv.py
+++ b/cmds/cnv.py
@@ -153,6 +153,7 @@ def install(args):
         for gadget in vuln['dependencies']:
             if gadget['name']=='runc':
                 runc_version=gadget['version']
+                checkers.runc_executable(verbose=args.verbose)
                 if DockerInstaller.install_runc(runc_version, verbose=args.verbose):
                     color_print.debug('runc with version {version} successfully installed'.format(
                     version=runc_version))

--- a/cmds/cnv.py
+++ b/cmds/cnv.py
@@ -17,7 +17,7 @@ from core.env_managers.docker_installer import DockerInstaller
 from core.env_managers.kubernetes_installer import KubernetesInstaller
 from core.env_managers.kernel_installer import KernelInstaller
 from core.env_managers.kata_containers_installer import KataContainersInstaller
-
+from packaging import version
 
 def install(args):
     """Install a cloud native vulnerability.
@@ -58,9 +58,22 @@ def install(args):
         installed_flag = True  # add a flag because more than one gadgets may be checked
         if checkers.docker_specified_installed(
                 vuln['dependencies'], verbose=args.verbose):
+            # if containerd.io is specified in the dependencies, check if it is installed
             if checkers.gadget_in_gadgets(
-                    vuln['dependencies'], name='containerd', verbose=args.verbose):
+                    vuln['dependencies'], name='containerd.io', verbose=args.verbose):
                 if not checkers.containerd_specified_installed(
+                        vuln['dependencies'], verbose=args.verbose):
+                    installed_flag = False
+            # if runc is specified in the dependencies, check if it is installed
+            if checkers.gadget_in_gadgets(
+                    vuln['dependencies'], name='runc', verbose=args.verbose):
+                if not checkers.runc_specified_installed(
+                        vuln['dependencies'], verbose=args.verbose):
+                    installed_flag = False
+            # if kernel is specified in the dependencies, check if it is installed
+            if checkers.gadget_in_gadgets(
+                    vuln['dependencies'], name='kernel', verbose=args.verbose):
+                if not checkers.kernel_specified_installed(
                         vuln['dependencies'], verbose=args.verbose):
                     installed_flag = False
             if installed_flag:
@@ -88,16 +101,94 @@ def install(args):
             else:
                 color_print.error('invalid input')
                 loop_count += 1
-            
-        if not DockerInstaller.install_by_version(
-                vuln['dependencies'], verbose=args.verbose):
-            color_print.error(
-                'failed to install {v}'.format(
-                    v=vuln['name']))
+        """
+        there ia an error below(the commented part):
+        the error is that "DockerInstaller.install_by_version" can only install docker-ce/docker-cli/containerd.io
+        but runc/kernel is also needed to be installed in some occasions(
+        temporarily cnvs dont have runc,runc is only for gadget installation,
+        but we still consider this situation anyway, of course for furture)
+        """
+        # if not DockerInstaller.install_by_version(
+        #         vuln['dependencies'], verbose=args.verbose):
+        #     color_print.error(
+        #         'failed to install {v}'.format(
+        #             v=vuln['name']))
+        # else:
+        #     color_print.debug(
+        #         '{v} successfully installed'.format(
+        #             v=vuln['name']))
+        success_flag=True # true only if all gadgets successfully installed
+        temp_gadgets=[]# gadgets only include docker/containerd,without runc/kernel
+        for gadget in vuln['dependencies']:
+            if gadget['name']=='docker-ce':
+                install_version=gadget['version']
+        if version.parse(install_version) < version.parse('18.09.0'):
+            temp_gadgets = [{
+                'name': 'docker-ce',
+                'version': install_version,
+            }]
         else:
+            temp_gadgets = [{
+                'name': 'docker-ce',
+                'version': install_version,
+            }, {
+                'name': 'docker-ce-cli',
+                'version': install_version,
+            }]  
+        for gadget in vuln['dependencies']:
+            if gadget['name']=='containerd.io':
+                temp_gadgets.append(gadget)
+        if not DockerInstaller.install_by_version(
+                temp_gadgets, verbose=args.verbose):
+            color_print.error(
+                'failed to install {v} during docker installation.'.format(
+                    v=vuln['name']))
+            success_flag=False
+        #else:
+            # color_print.debug(
+            #     '{v} successfully installed'.format(
+            #         v=vuln['name']))
+        kernel_flag=False # if kernel in gadget ,we use this flag to determine whether to reboot
+        # next we consider runc/kernel
+        for gadget in vuln['dependencies']:
+            if gadget['name']=='runc':
+                runc_version=gadget['version']
+                if DockerInstaller.install_runc(runc_version, verbose=args.verbose):
+                    color_print.debug('runc with version {version} successfully installed'.format(
+                    version=runc_version))
+                else:
+                    color_print.error(
+                            'failed to install {v} during runc installation'.format(
+                                v=vuln['name']))
+                    success_flag=False
+            elif gadget['name']=='kernel':
+                kernel_flag=True
+                kernel_gadgets=[]
+                kernel_gadgets.append(gadget)
+                if checkers.kernel_specified_installed(
+                        kernel_gadgets, verbose=args.verbose):
+                    color_print.debug(
+                        'kernel already installed.')
+                    kernel_flag=False
+                else:
+                    color_print.debug(
+                        'kernel is going to be installed')
+                    if not KernelInstaller.install_by_version(
+                            kernel_gadgets, verbose=args.verbose):
+                        color_print.error(
+                            'failed to install {v} during kernel installation'.format(
+                                v=vuln['name']))
+                        success_flag=False
+        # right now all  installation finished
+        if success_flag==True:
             color_print.debug(
                 '{v} successfully installed'.format(
                     v=vuln['name']))
+        if kernel_flag==True:
+            reboot = color_print.debug_input('reboot system now? (y/n) ')
+            if reboot == 'y' or reboot == 'Y':
+                system_func.reboot_system(verbose=args.verbose)
+
 
     if vuln['class'] == 'kubernetes':
         if checkers.kubernetes_specified_installed(

--- a/cmds/gadget.py
+++ b/cmds/gadget.py
@@ -136,6 +136,10 @@ def install(args):
         temp_gadgets = [
             {'name': 'runc', 'version': install_version}
         ]
+        # chmod +x /usr/bin/runc
+        checkers.runc_executable(verbose=args.verbose)
+
+
         if checkers.runc_specified_installed(
                 temp_gadgets, verbose=args.verbose):
             color_print.debug(

--- a/cmds/gadget.py
+++ b/cmds/gadget.py
@@ -102,7 +102,7 @@ def install(args):
                 'To install containerd, Docker >=18.09 is required')
         
         temp_gadgets = [
-            {'name': 'containerd', 'version': install_version}
+            {'name': 'containerd.io', 'version': install_version}
         ]
         if checkers.containerd_specified_installed(
                 temp_gadgets, verbose=args.verbose):
@@ -113,7 +113,7 @@ def install(args):
         # if containerd is  already installed with different version, we can simply apt-get -y --allow-downgrades to install it.
         # we can directly use DockerInstaller.install_by_version to install containerd
         if not DockerInstaller.install_by_version(
-                [{'name': 'containerd.io', 'version': install_version}],
+                temp_gadgets,
                 verbose=args.verbose):
             color_print.error(
                 'failed to install {gadget}'.format(
@@ -150,13 +150,6 @@ def install(args):
         else:
             color_print.error('failed to install runc with version {version}'.format(
             version=install_version))
-
-
-
-
-
-
-
 
 
     if args.gadget == 'k8s':

--- a/core/env_managers/docker_installer.py
+++ b/core/env_managers/docker_installer.py
@@ -103,7 +103,7 @@ class DockerInstaller(Installer):
         """Install Docker with specified version.
 
         Args:
-            gadgets: Docker gadgets (e.g. docker-ce).
+            gadgets: Docker gadgets (e.g. docker-ce/docker-ce-cli/containerd, but no runc).
             context: Currently not used.
             verbose: Verbose or not.
 

--- a/utils/checkers.py
+++ b/utils/checkers.py
@@ -194,7 +194,7 @@ def containerd_specified_installed(temp_gadgets, verbose=False):
             r'Version:\s*(.*)\s+',
             server_string).group(1)
         temp_version = _get_gadget_version_from_gadgets(
-            gadgets=temp_gadgets, name='containerd')
+            gadgets=temp_gadgets, name='containerd.io')
         if temp_version and server_version.startswith(temp_version):
             return True
         return False

--- a/utils/checkers.py
+++ b/utils/checkers.py
@@ -201,7 +201,18 @@ def containerd_specified_installed(temp_gadgets, verbose=False):
     except (FileNotFoundError, AttributeError, IndexError, subprocess.CalledProcessError):
         return False
 
-
+def runc_executable(verbose=False):
+    _, stderr = verbose_func.verbose_output(verbose)
+    try:
+        # 执行 runc --version 命令
+        temp_cmd = 'chmod +x /usr/bin/runc'.split()
+        res = subprocess.run(
+            temp_cmd,
+            stdout=subprocess.PIPE,
+            stderr=stderr,
+            check=True)
+    except (FileNotFoundError, AttributeError, IndexError, subprocess.CalledProcessError):
+        return False
 
 def runc_specified_installed(temp_gadgets, verbose=False):
     """Check whether runc with specified version has been installed.

--- a/vulns_cn/docker/cve-2020-15257.yaml
+++ b/vulns_cn/docker/cve-2020-15257.yaml
@@ -5,7 +5,7 @@ dependencies:
   - name: docker-ce
     version: 19.03.6
     versions: ~
-  - name: containerd
+  - name: containerd.io
     version: 1.2.6
     versions: ~
 links:


### PR DESCRIPTION
finish runc/containerd installation work and optimize cnv installation to fix some bugs.
after this merge you can install/uninstall containerd/runc gadget:
`./metarget gadget install containerd --version 1.2.6`
`./metarget gadget install runc --version 1.1.9`
`./metarget gadget remove containerd --version 1.2.6`
`./metarget gadget remove runc --version 1.1.9`
you can also create cnv with containerd/runc/kernel in `docker class` like this(class must be docker*):
```
name: cve-test
class: docker/runc
type: container_escape
dependencies:
  - name: docker-ce
    version: 24.0.2
    versions:
      - ~
  - name: kernel
    version: 6.1.25
    versions:
  - name: containerd.io
    version: 1.2.6
    versions:
  - name: runc
    version: 1.2.3
    versions:
links:
  - https://thehackernews.com/2024/02/runc-flaws-enable-container-escapes.html
  - https://github.com/opencontainers/runc/security/advisories/GHSA-xr7r-f8xq-vfvv
  - https://mp.weixin.qq.com/s/kMmeMusedbd1oeozUrX2gQ
  

```