### PR TITLE
Update requirements.txt and installer.py

### DIFF
--- a/core/env_managers/installer.py
+++ b/core/env_managers/installer.py
@@ -310,7 +310,8 @@ class Installer(object):
             'downloading {url} to {dst}'.format(
                 url=url, dst=save_path))
         res = requests.get(url, stream=True, proxies=proxies)
-        total_length = int(int(res.headers.get('content-length')) / 1024) + 1
+        content_length = res.headers.get('content-length')
+        total_length = int(int(content_length) / 1024) + 1 if content_length else None
         dst = save_path
         with open(dst, 'wb') as f:
             bar = tqdm(

--- a/core/env_managers/installer.py
+++ b/core/env_managers/installer.py
@@ -311,7 +311,10 @@ class Installer(object):
                 url=url, dst=save_path))
         res = requests.get(url, stream=True, proxies=proxies)
         content_length = res.headers.get('content-length')
-        total_length = int(int(content_length) / 1024) + 1 if content_length else None
+        if content_length:
+            total_length = int(int(content_length) / 1024) + 1 
+        else:
+            print("error to get content-length,please check url or internet")
         dst = save_path
         with open(dst, 'wb') as f:
             bar = tqdm(

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ PyYaml
 docker==5.0.0
 packaging
 requests
-beautifulsoup4
+beautifulsoup4==4.9.3
 tqdm
 prettytable==1.0.1


### PR DESCRIPTION
```bash
#uname -a
Linux ubuntu-virtual-machine 5.4.0-84-generic #94~18.04.1-Ubuntu SMP Thu Aug 26 23:17:46 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux
#python3 -V
Python 3.6.9
```
### 1. Update requirements.txt
```
Traceback (most recent call last):
  File "./metarget", line 14, in <module>
    import cmds.gadget
  File "/home/ubuntu/Desktop/vulEnv/metarget/cmds/gadget.py", line 11, in <module>
    from core.env_managers.kernel_installer import KernelInstaller
  File "/home/ubuntu/Desktop/vulEnv/metarget/core/env_managers/kernel_installer.py", line 16, in <module>
    import core.env_managers.package_list_downloader as package_list_downloader
  File "/home/ubuntu/Desktop/vulEnv/metarget/core/env_managers/package_list_downloader.py", line 6, in <module>
    from bs4 import BeautifulSoup
  File "/home/ubuntu/.local/lib/python3.6/site-packages/bs4/__init__.py", line 64, in <module>
    from .builder import (
  File "/home/ubuntu/.local/lib/python3.6/site-packages/bs4/builder/__init__.py", line 1
    from __future__ import annotations
    ^
SyntaxError: future feature annotations is not defined
```
**Problem analysis**
`from __future__ import annotations` is a feature supported only in Python 3.7 and higher versions. Its function is to defer the evaluation of type annotations, which helps avoid issues that may arise when using undefined types in type annotations. You are using Python 3.6, which does not support this feature. Therefore, an error occurs when importing the bs4 (BeautifulSoup) library.
**Solution**
Since the default Python 3 version in Ubuntu 18.04 is 3.6, change the version of beautifulsoup4 to 4.9.3.

### 2. Update installer.py
file: `core/env_managers/installer.py`
```
Traceback (most recent call last):
  File "./metarget", line 272, in <module>
    main()
  File "./metarget", line 265, in main
    args.func(args)
  File "/home/ubuntu/Desktop/vulEnv/metarget/cmds/cnv.py", line 152, in install
    gadgets=vuln['dependencies'], verbose=args.verbose):
  File "/home/ubuntu/Desktop/vulEnv/metarget/core/env_managers/kernel_installer.py", line 149, in install_by_version
    version, verbose=verbose)
  File "/home/ubuntu/Desktop/vulEnv/metarget/core/env_managers/kernel_installer.py", line 226, in _install_by_version_with_download
    config.kernel_packages_dir, filename))
  File "/home/ubuntu/Desktop/vulEnv/metarget/core/env_managers/installer.py", line 312, in download_file
    total_length = int(int(res.headers.get('content-length')) / 1024) + 1
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```

This error occurred because the `kernel_packages_list.yaml` file was not updated in a timely manner. However, I initially had no idea what was going on. Therefore, I suggest adding an error prompt here or automatically checking the timeliness of the YAML file when the program starts.