### PR TITLE
Add vulns_app/python/unpickle and Fix docker_to_k8s.sh

### DIFF
--- a/tools/docker_to_k8s.sh
+++ b/tools/docker_to_k8s.sh
@@ -12,6 +12,8 @@ for file in $(cat $1)
 do
 	file_backup=$file".backup"
 	cp $file $file_backup
+	# echo $file
+	# echo $file_backup
 
 	#Parsing file path
 	pre_path="vul_app"
@@ -21,6 +23,9 @@ do
 	cve=`echo $file_backup |awk -F '/' '{print $3}' | tr '[A-Z]' '[a-z]' | sed 's/\./'-'/g'`
 	cve2=`echo $file_backup |awk -F '/' '{print $3}' | sed 's/\./'-'/g'`
 	cve3=`echo $file_backup |awk -F '/' '{print $3}'`
+	# echo $cve
+	# echo $cve2
+	# echo $cve3
 	cve_path=$app_path"/"$cve2
 	# echo $cve_path
 
@@ -40,7 +45,11 @@ do
 	for k in ${srv_name[*]}
 	do
 		if [[ `grep $k $file_backup` ]];then
-			sed -i "s/$k/$cve"-"$k/g" $file_backup
+			# it works on linux:
+			sed -i "s/$k/${cve}-${k}/g" $file_backup
+			# on mac you need:
+			# an empty string tells `sed` not to create a backup file
+			# sed -i '' "s/$k/${cve}-${k}/g" $file_backup
 		fi
 	done
 
@@ -48,7 +57,12 @@ do
 	output_file=$cve_path"/"$cve".yaml"
 	home_path=`pwd`"/"
 	kompose convert -f $file_backup -o $output_file --volumes hostPath
+	
+	# it works on linux:
 	sed -i "s!$home_path!!g" $output_file
+	# on mac you need:
+	# an empty string tells `sed` not to create a backup file
+	# sed -i '' "s!$home_path!!g" $output_file
 
 	# Create desc.yaml
 	touch $outpath/desc.yaml

--- a/vulns_app/python/unpickle/desc.yaml
+++ b/vulns_app/python/unpickle/desc.yaml
@@ -1,0 +1,22 @@
+name:  python-unpickle-vuln
+class:  unpickle
+type:  rce
+description: |
+  Python's pickle module is a popular serialization/deserialization tool that converts Python objects into byte streams and vice versa. However, when untrusted data is deserialized using pickle, it can lead to arbitrary code execution.
+  This vulnerability occurs when an application deserializes user-controlled data using the pickle module without proper validation. An attacker can craft a malicious serialized object that, when deserialized, executes arbitrary commands on the target system.
+
+tags:
+  - python
+  - unpickle
+
+dependencies:
+  yamls:
+    - python-unpickle-deployment.yaml
+    - python-unpickle-service.yaml
+
+links:
+  - https://github.com/vulhub/vulhub/tree/master/python/unpickle/README.md
+  - http://rickgray.me/2015/09/12/django-command-execution-analysis.html
+  - https://www.leavesongs.com/PENETRATION/zhangyue-python-web-code-execute.html
+  - https://docs.python.org/3/library/pickle.html#pickle.loads
+  - https://intoli.com/blog/dangerous-pickles/

--- a/vulns_app/python/unpickle/python-unpickle-vuln-deployment.yaml
+++ b/vulns_app/python/unpickle/python-unpickle-vuln-deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ./unpickle/docker-compose.yml -o vul_app/python/unpickle/ --volumes hostPath
+    kompose.version: 1.35.0 (HEAD)
+  labels:
+    io.kompose.service: flask
+    app: flask
+    env: dev
+  name: flask
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: flask
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert -f ./unpickle/docker-compose.yml -o vul_app/python/unpickle/ --volumes hostPath
+        kompose.version: 1.35.0 (HEAD)
+      labels:
+        io.kompose.service: flask
+    spec:
+      containers:
+        - args:
+            - -w
+            - "4"
+            - -b
+            - :8000
+            - -u
+            - www-data
+            - -g
+            - www-data
+            - --access-logfile
+            - '-'
+            - app:app
+          image: sufwkevin/python-unpickle-vuln:latest
+          name: flask
+          ports:
+            - containerPort: 8000
+              protocol: TCP
+          imagePullPolicy: Always
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+      restartPolicy: Always
+

--- a/vulns_app/python/unpickle/python-unpickle-vuln-service.yaml
+++ b/vulns_app/python/unpickle/python-unpickle-vuln-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f ./unpickle/docker-compose.yml -o vul_app/python/unpickle/ --volumes hostPath
+    kompose.version: 1.35.0 (HEAD)
+    description: "This service exposes the Flask app running in a container."
+  labels:
+    io.kompose.service: flask
+  name: flask
+spec:
+  ports:
+    - name: "8000"
+      port: 8000
+      targetPort: 8000
+  selector:
+    io.kompose.service: flask
+  type: ClusterIP
+  sessionAffinity: ClientIP


### PR DESCRIPTION
1. Add vulns_app/python/unpickle: Python/unpickle deserialization vulnerability that executes malicious code.
2. Fix docker_to_k8s.sh: Supplement the correct command for running the seed on macOS.